### PR TITLE
Compatibility with varnish 6.0, 6.1 and 6.2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,9 +64,9 @@ offer then::
         --vsc=<list>         names of counters to build
         --vut=<list>         names of utilities to build
 
-*This is not obvious yet, but only Varnish 5.2.0 is supported, support for
-older versions than the latest needs to be added one way or another, probably
-via new plugins.*
+*This is not obvious yet, but only Varnish >= 6.0.0 is supported,
+support for older versions than the latest needs to be added one way
+or another, probably via new plugins.*
 
 It complains again, but this time the usage information show  a bit more
 capabilities (spoiler alert, not everything is implemented) so let's create a
@@ -118,7 +118,7 @@ not supported... No problem, let's build this project and see what it has::
     [...]
             ==== tutorial 0.1 ====
 
-            varnish:      5.2.0
+            varnish:      6.0.0
             prefix:       /usr
             vmoddir:      /usr/lib/varnish/vmods
             vcldir:       /usr/share/varnish/vcl

--- a/plugins/autotools--codegen.sh
+++ b/plugins/autotools--codegen.sh
@@ -84,7 +84,7 @@ AC_ARG_WITH([rst2man],
 	[RST2MAN="\$withval"],
 	AC_CHECK_PROGS(RST2MAN, [rst2man rst2man.py], []))
 
-VARNISH_PREREQ([5.2.0])
+VARNISH_PREREQ([6.0.0])
 ifelse({$vmod}, {}, {}, {dnl
 VARNISH_VMODS([translit({$vmod}, {,}, { })])
 })dnl
@@ -275,13 +275,10 @@ cat <<EOF
 #include "config.h"
 
 #include <cache/cache.h>
-#include <vdef.h>
-#include <vrt.h>
-#include <vcl.h>
 
 #include "vcc_$1_if.h"
 
-VCL_STRING __match_proto__(td_$1_hello)
+VCL_STRING
 vmod_hello(VRT_CTX)
 {
 
@@ -293,7 +290,7 @@ EOF
 
 src_vmod_vcc() {
 cat <<EOF
-\$Module $1 3 Varnish $1 Module
+\$Module $1 3 "Varnish $1 Module"
 
 DESCRIPTION
 ===========
@@ -335,6 +332,7 @@ cat <<EOF
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <signal.h>	// 6.2
 
 #define VOPT_DEFINITION
 #define VOPT_INC "$1_options.h"
@@ -342,8 +340,8 @@ cat <<EOF
 #include <vapi/voptget.h>
 #include <vapi/vsl.h>
 
-#include <vas.h>
 #include <vdef.h>
+#include <vas.h>
 #include <vut.h>
 
 static struct VUT *vut;
@@ -361,7 +359,7 @@ usage(int status)
 	exit(status);
 }
 
-static int __match_proto__(VSLQ_dispatch_f)
+static int
 dispatch(struct VSL_data *vsl, struct VSL_transaction * const *pt, void *priv)
 {
 
@@ -644,7 +642,7 @@ License:	XXX: put your license here
 URL:		XXX://put.your/url/here
 Source:		%{name}-%{version}.tar.gz
 
-BuildRequires:	pkgconfig(varnishapi) >= 5.2.0
+BuildRequires:	pkgconfig(varnishapi) >= 6.0.0
 
 %description
 XXX: put your long description here


### PR DESCRIPTION
* `cache.h` supersedes the other includes
* `__match_proto__` is only intended for use in varnish-cache
* include order to be compatible with all of the 6.[0-2] versions

supersedes #3 

@Dridi I tested on 6.0, 6.1 and master with `${VERSION_PREFIX}` set to an install prefix of that version

```
PREFIX=${VERSION_PREFIX}
export ACLOCAL_PATH=${PREFIX}/share/aclocal
export PKG_CONFIG_PATH=${PREFIX}/lib/pkgconfig
# from the README
vcdk autotools --pkg=rpm --vmod=foo,bar --vut=baz,qux --verbose tutorial
cd tutorial
make -j 20 distcheck
```