### PR TITLE
Fix&Renovate default configure.ac

### DIFF
--- a/plugins/autotools--codegen.sh
+++ b/plugins/autotools--codegen.sh
@@ -82,7 +82,7 @@ AC_ARG_WITH([rst2man],
 		[--with-rst2man=PATH],
 		[Location of rst2man (auto)]),
 	[RST2MAN="\$withval"],
-	AC_CHECK_PROGS(RST2MAN, [rst2man rst2man.py], []))
+	[AC_CHECK_PROGS(RST2MAN, [rst2man rst2man.py], [])])
 
 VARNISH_PREREQ([6.0.0])
 ifelse({$vmod}, {}, {}, {dnl

--- a/plugins/autotools--codegen.sh
+++ b/plugins/autotools--codegen.sh
@@ -66,7 +66,7 @@ AC_PREREQ([2.68])
 AC_INIT([$name], [0.1])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_AUX_DIR([build-aux])
-AC_CONFIG_HEADER([config.h])
+AC_CONFIG_HEADERS([config.h])
 
 AM_INIT_AUTOMAKE([1.12 -Wall -Werror foreign parallel-tests])
 AM_SILENT_RULES([yes])


### PR DESCRIPTION
* brackets were missing for `AC_ARG_WITH` arguments, resulting in a broken `configure` script
* `AC_CONFIG_HEADER` without an `S` is not obsolete as of autoconf 2.71